### PR TITLE
Fix uploadFile vuoto dopo request in 401

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfcc-webdav",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Salesforce Commerce Cloud simple webdav API",
   "keywords": [
     "Salesforce Commerce Cloud",


### PR DESCRIPTION
Una volta scaduto l'header di autenticazione la libreria riesegue la chiamata ma il fileStream è già stato consumato, caricando quindi il file vuoto.
Con questa fix viene rieseguita tutta la funzione fileUpload che reistanzia il fileStream